### PR TITLE
fix: deep config key comparison and add upgrade tests

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -48,6 +48,40 @@ function runWithOutput(cmd: string, args: string[], cwd: string): Promise<void> 
   });
 }
 
+/**
+ * Recursively find keys present in `defaults` but missing from `saved`.
+ * Returns dot-notation paths like "llm.newSetting".
+ */
+export function findMissingKeys(
+  saved: Record<string, unknown>,
+  defaults: Record<string, unknown>,
+  prefix = "",
+): string[] {
+  const missing: string[] = [];
+  for (const key of Object.keys(defaults)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (!(key in saved)) {
+      missing.push(path);
+    } else if (
+      typeof defaults[key] === "object" &&
+      defaults[key] !== null &&
+      !Array.isArray(defaults[key]) &&
+      typeof saved[key] === "object" &&
+      saved[key] !== null &&
+      !Array.isArray(saved[key])
+    ) {
+      missing.push(
+        ...findMissingKeys(
+          saved[key] as Record<string, unknown>,
+          defaults[key] as Record<string, unknown>,
+          path,
+        ),
+      );
+    }
+  }
+  return missing;
+}
+
 export function createUpgradeCommand(program: Command): Command {
   return new Command("upgrade")
     .description("Update snip CLI and re-install integrations")
@@ -188,7 +222,7 @@ export function createUpgradeCommand(program: Command): Command {
             readFileSync(getConfigPath(), "utf-8"),
           ) as Record<string, unknown>;
           const defaults = getDefaultConfig();
-          const newKeys = Object.keys(defaults).filter((k) => !(k in raw));
+          const newKeys = findMissingKeys(raw, defaults as unknown as Record<string, unknown>);
           if (newKeys.length > 0) {
             console.log(`\nNew config keys (auto-applied from defaults): ${newKeys.join(", ")}`);
           }

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { findMissingKeys } from "../src/commands/upgrade.js";
+
+describe("findMissingKeys", () => {
+  it("detects missing top-level keys", () => {
+    const saved = { a: 1, b: 2 };
+    const defaults = { a: 1, b: 2, c: 3 };
+    expect(findMissingKeys(saved, defaults)).toEqual(["c"]);
+  });
+
+  it("returns empty array when saved matches defaults", () => {
+    const saved = { a: 1, b: 2 };
+    const defaults = { a: 1, b: 2 };
+    expect(findMissingKeys(saved, defaults)).toEqual([]);
+  });
+
+  it("returns empty array when saved has extra keys", () => {
+    const saved = { a: 1, b: 2, extra: "ok" };
+    const defaults = { a: 1, b: 2 };
+    expect(findMissingKeys(saved, defaults)).toEqual([]);
+  });
+
+  it("detects missing nested keys with dot-notation paths", () => {
+    const saved = { llm: { provider: "ollama" } };
+    const defaults = { llm: { provider: "ollama", newSetting: true } };
+    expect(findMissingKeys(saved, defaults)).toEqual(["llm.newSetting"]);
+  });
+
+  it("detects deeply nested missing keys", () => {
+    const saved = { a: { b: { c: 1 } } };
+    const defaults = { a: { b: { c: 1, d: 2 } } };
+    expect(findMissingKeys(saved, defaults)).toEqual(["a.b.d"]);
+  });
+
+  it("reports entire missing nested object as single key", () => {
+    const saved = { a: 1 };
+    const defaults = { a: 1, nested: { x: 1, y: 2 } };
+    expect(findMissingKeys(saved, defaults)).toEqual(["nested"]);
+  });
+
+  it("handles mix of top-level and nested missing keys", () => {
+    const saved = {
+      libraryPath: "/home/user/snippets",
+      llm: { provider: "ollama", ollamaModel: "llama3.1" },
+    };
+    const defaults = {
+      libraryPath: "/home/user/snippets",
+      newTopLevel: "value",
+      llm: { provider: "ollama", ollamaModel: "llama3.1", newNested: "value" },
+    };
+    expect(findMissingKeys(saved, defaults)).toEqual([
+      "newTopLevel",
+      "llm.newNested",
+    ]);
+  });
+
+  it("does not recurse into arrays", () => {
+    const saved = { types: ["snippets"] };
+    const defaults = { types: ["snippets", "prompts"] };
+    // Arrays are values, not objects to recurse into — no missing keys
+    expect(findMissingKeys(saved, defaults)).toEqual([]);
+  });
+
+  it("does not recurse when saved value is non-object", () => {
+    const saved = { llm: "flat-string" };
+    const defaults = { llm: { provider: "ollama" } };
+    // saved.llm is a string, not an object — can't recurse, not "missing"
+    expect(findMissingKeys(saved, defaults)).toEqual([]);
+  });
+
+  it("handles real SnipConfig shape", () => {
+    const saved = {
+      libraryPath: "/home/user/snippets",
+      types: ["snippets", "prompts"],
+      defaultType: "snippets",
+      editor: "vi",
+      llm: {
+        provider: "ollama",
+        ollamaModel: "llama3.1",
+        ollamaHost: "http://localhost:11434",
+        fallbackProvider: null,
+        openaiApiKey: null,
+        anthropicApiKey: null,
+      },
+      qmd: { collectionName: "snip" },
+      // alfred section missing entirely
+    };
+    const defaults = {
+      libraryPath: "/home/user/snippets",
+      types: ["snippets", "prompts"],
+      defaultType: "snippets",
+      editor: "vi",
+      llm: {
+        provider: "ollama",
+        ollamaModel: "llama3.1",
+        ollamaHost: "http://localhost:11434",
+        fallbackProvider: null,
+        openaiApiKey: null,
+        anthropicApiKey: null,
+      },
+      qmd: { collectionName: "snip" },
+      alfred: { maxResults: 20 },
+    };
+    expect(findMissingKeys(saved, defaults)).toEqual(["alfred"]);
+  });
+});


### PR DESCRIPTION
## Summary
- **snip-a0u**: Config migration in `snip upgrade` now recursively compares nested keys (e.g., `llm.newSetting`, `alfred.maxResults`) instead of only top-level keys. Uses dot-notation paths in the output.
- **snip-tft**: Adds 10 tests for the `findMissingKeys` function covering top-level, nested, deeply nested, array, type-mismatch, and real `SnipConfig` shapes.

## Changes
- `src/commands/upgrade.ts`: Extracted `findMissingKeys()` (exported for testing) that recursively walks both objects. Replaced the flat `Object.keys().filter()` call.
- `tests/upgrade.test.ts`: New test file with 10 test cases.

## Test plan
- [x] All 47 tests pass (`npm test`)
- [x] Typecheck passes (`npm run typecheck`)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: Pure logic change with no runtime/production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)